### PR TITLE
File extensions are not a requirement

### DIFF
--- a/vars.go
+++ b/vars.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -106,18 +105,17 @@ func addVarsFromFile(currentVars map[string]string, path string) error {
 		// Group or Host doesn't exist in the inventory, ignoring
 		return nil
 	}
-	ext := filepath.Ext(path)
-	if ext != ".yaml" && ext != ".yml" {
-		return nil
-	}
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	vars := make(map[string]interface{})
 	err = yaml.Unmarshal(f, &vars)
 	if err != nil {
-		return err
+		// XXX: file extensions dont matter in ansible, but if we cannot parse a file, its not a valid file
+		// dont return an error here so we can continue to walk
+		// should this parsing error really stop us from parsing more potential files?
+		return nil
 	}
 	for k, v := range vars {
 		switch v := v.(type) {


### PR DESCRIPTION
Hey there! Thank you for making this awesome library!

Trying to use it on our ansible inventories and group_vars structure led to some weird results where I could not parse any of our group_vars properly.

I found that in the library there is a hard requirement on having group_var files with extensions: https://github.com/relex/aini/blob/b67a1e990856ac488c888cab9bfcda9fe62015df/vars.go#L110-L112 This requirement is not in ansible itself, as we have no problems with our current structure.


## Current ansible use case
Here is an example structure that works fine with ansible:
```
$ tree inventories
inventories
├── group_vars
│   ├── group_a
│   └── some_awesome_cluster
└── some_awesome_cluster
```
```
$ cat inventories/some_awesome_cluster
[group_a]
a-beefy-server          ansible_host=12.34.56.78    private_ip=192.168.0.53    machine_id=foo124

[some_awesome_cluster:children]
group_a
```
```
$ cat inventories/group_vars/some_awesome_cluster
cluster_name: awesome
region: eu-west-2
$ cat inventories/group_vars/group_a
something: here
```

Ansible `[core 2.17.6]`  does not have any issue with the file naming:
```json
$ ansible-inventory -i inventories/some_awesome_cluster --list
{
    "_meta": {
        "hostvars": {
            "a-beefy-server": {
                "ansible_host": "12.34.56.78",
                "cluster_name": "awesome",
                "machine_id": "foo124",
                "private_ip": "192.168.0.53",
                "region": "eu-west-2",
                "something": "here"
            }
        }
    },
    "all": {
        "children": [
            "ungrouped",
            "some_awesome_cluster"
        ]
    },
    "group_a": {
        "hosts": [
            "a-beefy-server"
        ]
    },
    "some_awesome_cluster": {
        "children": [
            "group_a"
        ]
    }
}
```


`ainidump` (from commit `b67a1e990856ac488c888cab9bfcda9fe62015df`) output on the same inventory/group_vars files (notice lack of group_vars):
```json
$ go run ./cmd/ainidump ./inventories/some_awesome_cluster
{
    "Hosts": [
        {
            "Name": "a-beefy-server",
            "Groups": [
                "group_a",
                "some_awesome_cluster",
                "all"
            ],
            "Vars": {
                "ansible_host": "12.34.56.78",
                "machine_id": "foo124",
                "private_ip": "192.168.0.53"
            }
        }
    ],
    "Groups": [
        {
            "Name": "all",
            "Parents": [],
            "Descendants": [
                "group_a",
                "some_awesome_cluster",
                "ungrouped"
            ],
            "Hosts": [
                "a-beefy-server"
            ],
            "Vars": {}
        },
        {
            "Name": "group_a",
            "Parents": [
                "some_awesome_cluster",
                "all"
            ],
            "Descendants": [],
            "Hosts": [
                "a-beefy-server"
            ],
            "Vars": {}
        },
        {
            "Name": "some_awesome_cluster",
            "Parents": [
                "all"
            ],
            "Descendants": [
                "group_a"
            ],
            "Hosts": [
                "a-beefy-server"
            ],
            "Vars": {}
        },
        {
            "Name": "ungrouped",
            "Parents": [
                "all"
            ],
            "Descendants": [],
            "Hosts": [],
            "Vars": {}
        }
    ]
}
```

## Open Question / Discussion
If we don't care about the file extension, when we parse what we expect to be the vars from a YAML format, and we get an error from `yaml.Unmarshal`: https://github.com/relex/aini/blob/b67a1e990856ac488c888cab9bfcda9fe62015df/vars.go#L118-L121
We kinda have to ignore it, or maybe print out warnings?

With the current test coverage at least, because it has `junk_file.txt`, we can't actually return an error here, or we never end up reading the `some_vars.yml` file.

How would you want to better handle this in tests?
I realize its not a great idea to ignore parsing errors here, but I question why there is even a `junk_file.txt` to begin with, as ansible should just ignore it too.

### Minor deprecation changes
* `ioutil.ReadFile` is deprecated use `os.ReadFile` instead